### PR TITLE
Update style.css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,7 +162,8 @@ pre {
 .icons-flex img {
   display: block;
   font-size: 3em;
-  margin: 0.3em auto;
+  margin: 0 auto;
+  padding: 0.3em 0;
 }
 
 .icons-flex img {


### PR DESCRIPTION
Fixed .icons-flex not to trigger <a> between icon and the label

Before:
![image](https://user-images.githubusercontent.com/2377891/48410224-48ca3480-e73e-11e8-90ae-70a7f3a5532c.png)
After:
![image](https://user-images.githubusercontent.com/2377891/48410317-8929b280-e73e-11e8-969b-92a5afe2c621.png)
