### PR TITLE
Změna odkazu na českou komunitu Debianu

### DIFF
--- a/_pages/kde-ziskat.md
+++ b/_pages/kde-ziskat.md
@@ -167,7 +167,7 @@ elementary OS používá vlastní grafické prostředí Pantheon.
 Debian **vyvíjejí dobrovolníci** a tedy vždy a za všech okolností zůstane svobodným softwarem.
   '
   community='Česká komunita Debianu' community_link='https://www.debian-linux.cz/'
-  support='Podpora' support_link='https://www.debian.org/support'
+  support='Podpora' support_link='https://forum.debian-linux.cz/'
   website='Oficiální stránky' website_link='https://www.debian.org/'
   download='Stáhnout Debian' download_link='https://www.debian.org/distrib/'
 %}

--- a/_pages/kde-ziskat.md
+++ b/_pages/kde-ziskat.md
@@ -166,7 +166,7 @@ elementary OS používá vlastní grafické prostředí Pantheon.
 
 Debian **vyvíjejí dobrovolníci** a tedy vždy a za všech okolností zůstane svobodným softwarem.
   '
-  community='Česká komunita Debianu' community_link='https://www.debian.cz/'
+  community='Česká komunita Debianu' community_link='https://www.debian-linux.cz/'
   support='Podpora' support_link='https://www.debian.org/support'
   website='Oficiální stránky' website_link='https://www.debian.org/'
   download='Stáhnout Debian' download_link='https://www.debian.org/distrib/'


### PR DESCRIPTION
Web [debian-linux.cz](https://www.debian-linux.cz) se zdá být podstatně aktivnější a pro uživatele přínosnější, než zastaralý, ne příliš aktualizovaný [debian.cz](https://www.debian.cz).